### PR TITLE
Compare the checksums as integers.

### DIFF
--- a/lib/nmea.ex
+++ b/lib/nmea.ex
@@ -5,7 +5,7 @@ defmodule NMEA do
   More information on [Wikipedia](https://en.wikipedia.org/wiki/NMEA_0183)
   """
 
-  use Bitwise
+  import Bitwise, only: [bxor: 2]
 
   @doc """
   Parse a datagram.
@@ -37,10 +37,7 @@ defmodule NMEA do
       text
       |> String.to_charlist()
       |> Enum.reduce(0, &bxor/2)
-      |> to_hex()
 
-    expected == checksum
+    expected == String.to_integer(checksum, 16)
   end
-
-  defp to_hex(n), do: Integer.to_string(n, 16)
 end

--- a/test/nmea_test.exs
+++ b/test/nmea_test.exs
@@ -37,4 +37,9 @@ defmodule NMEATest do
                  "23"
                ]}}
   end
+
+  test "with zero padded checksum" do
+    assert NMEA.parse("$IIMWV,332.8,R,15.5,M,A*05") ==
+             {:ok, {"II", "MWV", ["332.8", "R", "15.5", "M", "A"]}}
+  end
 end


### PR DESCRIPTION
Some sensors zero pad the checksum value and that makes the checksum check fail.

(also fixed a deprecation warning).